### PR TITLE
KUP-57: Api Review

### DIFF
--- a/krules_core/arg_processors/__init__.py
+++ b/krules_core/arg_processors/__init__.py
@@ -15,6 +15,9 @@ processors = []
 
 
 class BaseArgProcessor:
+    """
+    *Base Argument Processor class in which base methods are defined*
+    """
 
     def __init__(self, arg):
         self._arg = arg
@@ -22,31 +25,56 @@ class BaseArgProcessor:
     @staticmethod
     def interested_in(arg):
         """
-        return: True if arg must be processed by this class False if not.
+        Returns:
+            True if arg must be processed by this class False if not.
         """
+
         raise NotImplementedError()
 
     def process(self, instance):
         """
-        return: Processed argument.
+        Returns:
+            Processed argument.
         """
+
         raise NotImplementedError()
 
 
 class DefaultArgProcessor(BaseArgProcessor):
+    """
+    *A simple Argument Processor which returns the argument itself.*
+    """
 
     @staticmethod
     def interested_in(arg):
+        """
+        Returns:
+            Always True.
+        """
+
         return True
 
     def process(self, instance):
+        """
+        Returns:
+            Argument itself.
+        """
+
         return self._arg
 
 
 class SimpleCallableArgProcessor(BaseArgProcessor):
+    """
+    *An Argument Processor specific for callable without parameters.*
+    """
 
     @staticmethod
     def interested_in(arg):
+        """
+        Returns:
+            True if the argument is a function which not expect any parameters.
+        """
+
         try:
             sig = inspect.signature(arg)
             return len(sig.parameters) == 0
@@ -54,6 +82,11 @@ class SimpleCallableArgProcessor(BaseArgProcessor):
             return False
 
     def process(self, _):
+        """
+        Returns:
+            Argument execution result.
+        """
+
         return self._arg()
 
 
@@ -61,9 +94,17 @@ processors.append(SimpleCallableArgProcessor)
 
 
 class CallableWithSelfArgProcessor(BaseArgProcessor):
+    """
+    *An Argument Processor specific for callable with *self* as unique parameter.*
+    """
 
     @staticmethod
     def interested_in(arg):
+        """
+        Returns:
+            True if the argument is a function which expect only self as unique argument.
+        """
+
         try:
             sig = inspect.signature(arg)
             return len(sig.parameters) == 1 and "self" in sig.parameters
@@ -71,6 +112,11 @@ class CallableWithSelfArgProcessor(BaseArgProcessor):
             return False
 
     def process(self, instance):
+        """
+        Returns:
+            Argument execution result passing RuleFunction instance as argument.
+        """
+
         return self._arg(instance)
 
 
@@ -78,9 +124,17 @@ processors.append(CallableWithSelfArgProcessor)
 
 
 class CallableWithPayloadArgProcessor(BaseArgProcessor):
+    """
+    *An Argument Processor specific for callable with *payload* as unique parameter.*
+    """
 
     @staticmethod
     def interested_in(arg):
+        """
+        Returns:
+            True if the argument is a function which expect only *payload* as unique argument.
+        """
+
         try:
             sig = inspect.signature(arg)
             return len(sig.parameters) == 1 and "payload" in sig.parameters
@@ -88,6 +142,11 @@ class CallableWithPayloadArgProcessor(BaseArgProcessor):
             return False
 
     def process(self, instance):
+        """
+        Returns:
+            Return the argument execution result passing RuleFunction instance payload as argument.
+        """
+
         return self._arg(instance.payload)
 
 
@@ -95,9 +154,17 @@ processors.append(CallableWithPayloadArgProcessor)
 
 
 class CallableWithSubjectArgProcessor(BaseArgProcessor):
+    """
+    *An Argument Processor specific for callable with *subject* as unique parameter.*
+    """
 
     @staticmethod
     def interested_in(arg):
+        """
+        Returns:
+            True if the argument is a function which expect only *subject* as unique argument.
+        """
+
         try:
             sig = inspect.signature(arg)
             return len(sig.parameters) == 1 and "subject" in sig.parameters
@@ -105,9 +172,12 @@ class CallableWithSubjectArgProcessor(BaseArgProcessor):
             return False
 
     def process(self, instance):
+        """
+        Returns:
+            Return the argument execution result passing RuleFunction instance subject as argument.
+        """
+
         return self._arg(instance.subject)
 
 
 processors.append(CallableWithSubjectArgProcessor)
-
-

--- a/krules_core/base_functions/__init__.py
+++ b/krules_core/base_functions/__init__.py
@@ -81,7 +81,7 @@ class RuleFunctionBase:
     subject = object()  # just for the ide happiness
 
     payload = {}
-    type = ""
+    event_type = ""
 
     def __init__(self, *args, **kwargs):
         self._args = []

--- a/krules_core/base_functions/filters.py
+++ b/krules_core/base_functions/filters.py
@@ -16,57 +16,65 @@ from krules_core.base_functions import RuleFunctionBase
 import inspect
 
 
-class Returns(RuleFunctionBase):
+class Filter(RuleFunctionBase):
     """
-    Simply returns expression
+    *Evaluates a boolean expression and returns its value.*
+    *The best way to exploit it is to use it in combination with* `Argument Processors <https://intro.krules.io/ArgumentProcessors.html>`_.
+
+    ::
+
+        {
+            rulename: "filtered-rules",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    Filter(
+                        lambda payload:(
+                            "my-label" in payload["object"]["metadata"].get("labels", {})
+                        )
+                    ),
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        }
+
     """
 
-    def execute(self, expression):
+    def execute(self, value):
         """
         Args:
-            expression: We expect expression to be something callable that can be evaluated
+            value: Boolean expression which will be evaluated
         """
-        return expression
-
-
-class IsTrue(Returns):
-    """
-    True if True
-    """
-
-    def execute(self, expression):
-        """
-        Args:
-            expression: We expect expression to be something callable that can be evaluated as a boolean
-        """
-
-        return bool(super().execute(expression))
-
-
-class IsFalse(Returns):
-    """
-    True if False
-    """
-
-    def execute(self, expression):
-        """
-        Args:
-            expression: We expect expression to be something callable that can be evaluated as a boolean
-        """
-
-        return not bool(super().execute(expression))
+        return value
 
 
 class SubjectNameMatch(RuleFunctionBase):
     """
-    Checks if the subject's name matches the **regular expression**
+    *Return True if the subject's name matches the given regular expression*
+
+    ::
+
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    SubjectNameMatch(r"^user\|(?P<user_id>.+)", payload_dest="user_id"),
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        }
     """
 
     def execute(self, regex, payload_dest="subject_match"):
         """
         Args:
-            regex: Check expression
-            payload_dest: Name of the key in the payload where the value of any groups contained in the expression is saved
+            regex: Regular expression which will be evaluated
+            payload_dest: Name of the key in the payload where the value of any groups contained in the expression will be saved saved
         """
         import re
         match = re.search(regex, self.subject.name)
@@ -78,76 +86,122 @@ class SubjectNameMatch(RuleFunctionBase):
 
 class SubjectNameDoesNotMatch(SubjectNameMatch):
     """
-    Opposite of CheckSubjectNameMatch
+    *Return True if the subject's name does not match the given regular expression*
     """
 
     def execute(self, regex, **kwargs):  # TODO: best inheritage support (**kwargs satisfy base class signature)
+        """
+        Args:
+            regex: Regular expression which will be evaluated
+        """
 
         return not super().execute(regex)
 
 
 class CheckSubjectProperty(RuleFunctionBase):
     """
-    Check the value of a property in the subject
-    If the property does not exists returns False
+    *Returns True if the given subject property exists and, if provided, match the given value.*
+
+    ::
+
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    CheckSubjectProperty(
+                        "last_update",
+                        property_value=lambda payload:(
+                            lambda value: value < payload.get("update_time")
+                        )
+                    ),
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        }
     """
 
-    def execute(self, property_name, property_value=lambda _none_: None, extended=False, cached=True):
+    def execute(self, property_name, property_value=lambda _none_: None, extended=False, use_cache=True):
         """
         Args:
             property_name: The name of the property
-            property_value: Value to compare. If omitted, only the presence of the property is checked.
-              If a callable is provided, this is invoked (optionally) with the property value
-            See tests for examples
-            extended: If True, check extended property
-            cached: If False it checks the actual value on the storage backend bypassing the cached value
+            property_value(optional): Could be the expected property value or a callable which takes the actual property value as unique parameter. It is possible to exploit the `Argument Processors <https://intro.krules.io/ArgumentProcessors.html>`_ to get the expected property value using nested lambda (as in exmaple).
+            extended: If True, check extended property [default False]
+            use_cache: If False it checks the actual value on the storage backend bypassing the cached value [default True]
         """
-        if property_name not in self.subject:
+
+        if (property_name not in self.subject and not extended) or (
+                extended and property_name not in self.subject.get_ext_props()):
             return False
+
         _get = extended and self.subject.get_ext or self.subject.get
         if inspect.isfunction(property_value):
             sign = inspect.signature(property_value)
             if str(sign) == '(_none_)':
                 return True
-            n_args = len(sign.parameters)
-            args = []
-            if n_args > 0:
-                args.append(_get(property_name, cached=cached))
-            # if n_args > 1:
-            #     args.append(self.payload)
-            return property_value(*args)
-        return _get(property_name, cached=cached) == property_value
+            return property_value(_get(property_name, use_cache=use_cache))
+        return _get(property_name, use_cache=use_cache) == property_value
 
 
 class PayloadMatch(RuleFunctionBase):
     """
-    It allows to process the payload with a jsonpath expression to check its content and possibly isolate part of it
-    in a target variable
+    *Processes the payload with a given jsonpath expression to check its content.*
+
+    ::
+
+        # event payload = {
+        #     "user": "admin",
+        #     "skills": [{"id": 1, "rating": 85}, {"id": 2, "value": 53}, {"id": 3, "value": 98}]}
+        # }
+
+
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    PayloadMatch("$.user", "admin"), # return False because with single_match = False match result is always a list
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        },
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    PayloadMatch("$.user", "admin", single_match=True), # return True
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        },
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    PayloadMatch("$.data[?@.rating>80]", lambda x: len(x) == 2, payload_dest="qualified_skills")
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        },
     """
 
     def execute(self, jp_expr, match_value=lambda _none_: None, payload_dest=None, single_match=False):
         """
         Args:
-            jp_expr: Jsonpath expression
-            payload_dest: If specified store the epression match result in that key in payload
-            match_value: It can be both the expected value of the jsonpath expression processing or a boolean function
-            that handles the expression result.
-            single_match: if True produce a single value as result, a list of values otherwise
-
-        >>> payload = {
-        >>>             "user": "admin",
-        >>>             "data": [{"id": 1, "value": 200}, {"id": 2, "value": 90}, {"id": 3, "value": 250}]}
-        >>>         }
-        >>> PayloadMatch("$.user", "admin")
-        >>> False
-        >>> PayloadMatch("$.user", "admin", single_match=True)
-        >>> True
-        >>> PayloadMatch("$.data[?@.value>100]")
-        >>> True
-        >>> PayloadMatch("$.data[?@.value>100]", [1, 3])
-        >>> False
-        >>> PayloadMatch("$.data[?@.value>100]", lambda x: len(x) == 2)
-        >>> True
+            jp_expr: Jsonpath expression which will be used to process the payload.
+            payload_dest: Payload key in which match result will be stored. If None, no result will be saved. [default None]
+            match_value: It can be both the expected value of the jsonpath expression processing or a boolean function that handles the expression result.
+            single_match: If True produces a single value as result, a list of values otherwise [default False]
         """
 
         import jsonpath_rw_ext as jp
@@ -167,12 +221,7 @@ class PayloadMatch(RuleFunctionBase):
         if inspect.isfunction(match_value):
             sign = inspect.signature(match_value)
             if str(sign) != '(_none_)':
-                n_args = len(sign.parameters)
-                args = []
-                if n_args > 0:
-                    args.append(match)
-
-                matched = match_value(*args)
+                matched = match_value(match)
         else:
             matched = match == match_value
 
@@ -181,7 +230,22 @@ class PayloadMatch(RuleFunctionBase):
 
 class PayloadMatchOne(PayloadMatch):
     """
-    Same as CheckPayloadJPMatch but expects just one element as result
+    *Extends PayloadMatch defaulting single_match to True and so expects just one element as result*
+
+    ::
+
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    PayloadMatchOne("$.user", "admin"), # return True, it is the same as PayloadMatch("$.user", "admin", single_match=True)
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        }
     """
 
     def execute(self, jp_expr, match_value=lambda _none_: None, payload_dest=None, **kwargs):
@@ -193,21 +257,134 @@ class PayloadMatchOne(PayloadMatch):
         return super().execute(jp_expr, match_value, payload_dest, True)
 
 
-class SubjectPropertyChanged(RuleFunctionBase):
+class OnSubjectPropertyChanged(RuleFunctionBase):
     """
-    Catch the event subject property changed
+    *Specific function to filter* **subject-property-changed** *event.
+    This event is produced whenever a subject property changes and its data contains the property name, the new property value and the old one.*
+
+    ::
+
+        ☁️  cloudevents.Event
+        Validation: valid
+        Context Attributes,
+          specversion: 1.0
+          type: subject-property-changed
+          source: my-ruleset
+          subject: foo
+          id: bd198e83-9d7e-4e93-a9ae-aa21a40383c6
+          time: 2020-06-16T08:16:57.340692Z
+          datacontenttype: application/json
+        Extensions,
+          knativearrivaltime: 2020-06-16T08:16:57.346535873Z
+          originid: bd198e83-9d7e-4e93-a9ae-aa21a40383c6
+          propertyname: count
+          traceparent: 00-d571530282362927f824bae826e1fa36-a52fceb915060653-00
+        Data,
+          {
+            "property_name": "count",
+            "old_value": 0,
+            "value": 1
+          }
+
+    *It is important to note that the property name is also present also in the event's extensions and can therefore be used as a filter in a Trigger to intercept changes only of a specific property.*
+
+    ::
+
+        apiVersion: eventing.knative.dev/v1
+        kind: Trigger
+        metadata:
+          name: on-count-change-trigger
+        spec:
+          filter:
+            attributes:
+              propertyname: count
+              type: subject-property-changed
+          subscriber:
+            ref:
+              apiVersion: v1
+              kind: Service
+              name: on-count-change-handler
+
+    *This function allows you to exec your rule only when a specific property changes and, optionally, only for a specific current or previous value of it.*
+
+    ::
+
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    SetSubjectProperty("count", lambda x: x + 1), # Since in this case the event will be handled within the ruleset itself,
+                                                                  # it is not necessary to define any trigger to intercept it
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        },
+        {
+            rulename: "...",
+            subscibre_to: "subject-property-changed",
+            ruledata: {
+                filters: [
+                    SubjectPropertyChanged("count"), # Exec processing section each time property count changes
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        },
+        {
+            rulename: "...",
+            subscibre_to: "subject-property-changed",
+            ruledata: {
+                filters: [
+                    SubjectPropertyChanged(
+                        "count",
+                        value=lambda v: v%2 == 0
+                    ), # Exec processing section each time a new even value is assigned to property count
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        },
+        {
+            rulename: "...",
+            subscibre_to: "subject-property-changed",
+            ruledata: {
+                filters: [
+                    SubjectPropertyChanged("count", old_value=0), # Exec processing section each time property count changes and
+                                                                  # its old value is equal to 0
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        },
+        {
+            rulename: "...",
+            subscibre_to: "subject-property-changed",
+            ruledata: {
+                filters: [
+                    SubjectPropertyChanged(
+                        "count",
+                        value=lambda v, o: v > 10 && o%2 == 1
+                    ), # Exec processing section each time a new value greater than 10 is assigned to property count and its last value was odd
+                ]
+                processing: [
+                    ...
+                ]
+            }
+        },
     """
 
     def execute(self, property_name, value=lambda _none_: None, old_value=lambda _none_: None):
         """
         Args:
-            property_name: Name of property changed. Accept callable receiving (optionally) the property name, In that
-               case it must returns a boolean
-            value: If not a callable the value is compared, otherwise it can receive no parameters,
-               or the value of the property and eventually also the previous value of the property (old_value).
-               It must returns a boolean
-            old_value: If not a callable the value is compared, otherwise it receives (optionally) the old_value and
-               must returns a boolean
+            property_name: Name of the changed property. Could be a string, a callable with no args which returns the property name or a boolean callable which accepts the property name as unique parameter
+            value: Could be the expected value or  a boolean callable which takes as arguments just the new property value or the new value and the previous one. It is possible to exploit the `Argument Processors <https://intro.krules.io/ArgumentProcessors.html>`_ to get the expected property value.
+            old_value: Could be the expected previous property value or a boolean callable which takes as arguments the previous property value. It is possible to exploit the `Argument Processors <https://intro.krules.io/ArgumentProcessors.html>`_ to get the expected old property value.
         """
 
         # property_name
@@ -231,9 +408,7 @@ class SubjectPropertyChanged(RuleFunctionBase):
             sign = inspect.signature(value)
             if str(sign) != '(_none_)':
                 n_args = len(sign.parameters)
-                if n_args == 0:
-                    matched = self.payload[PayloadConst.VALUE] == value()
-                elif n_args == 1:
+                if n_args == 1:
                     matched = value(self.payload[PayloadConst.VALUE])
                 elif n_args == 2:
                     args = [self.payload[PayloadConst.VALUE], self.payload[PayloadConst.OLD_VALUE]]  # for IDE happiness
@@ -251,9 +426,7 @@ class SubjectPropertyChanged(RuleFunctionBase):
             sign = inspect.signature(old_value)
             if str(sign) != '(_none_)':
                 n_args = len(sign.parameters)
-                if n_args == 0:
-                    matched = self.payload[PayloadConst.OLD_VALUE] == old_value()
-                elif n_args == 1:
+                if n_args == 1:
                     matched = old_value(self.payload[PayloadConst.OLD_VALUE])
                 else:
                     raise TypeError("takes at most two arguments (received {})".format(n_args))

--- a/krules_core/base_functions/filters.py
+++ b/krules_core/base_functions/filters.py
@@ -149,6 +149,7 @@ class PayloadMatch(RuleFunctionBase):
     """
     *Processes the payload with a given jsonpath expression to check its content.*
 
+
     ::
 
         # event payload = {
@@ -193,39 +194,6 @@ class PayloadMatch(RuleFunctionBase):
                 ]
             }
         },
-    """
-
-    def execute(self, jp_expr, match_value=lambda _none_: None, payload_dest=None, single_match=False):
-        """
-        Args:
-            jp_expr: Jsonpath expression which will be used to process the payload.
-            payload_dest: Payload key in which match result will be stored. If None, no result will be saved. [default None]
-            match_value: It can be both the expected value of the jsonpath expression processing or a boolean function that handles the expression result.
-            single_match: If True produces a single value as result, a list of values otherwise [default False]
-        """
-
-        import jsonpath_rw_ext as jp
-
-        matched = False
-        fn = jp.match
-        if single_match:
-            fn = jp.match1
-
-        match = fn(jp_expr, self.payload)
-        if match is not None and len(match):
-            matched = True
-
-        if payload_dest:
-            self.payload[payload_dest] = match
-
-        if inspect.isfunction(match_value):
-            sign = inspect.signature(match_value)
-            if str(sign) != '(_none_)':
-                matched = match_value(match)
-        else:
-            matched = match == match_value
-
-        return matched
 
 
 class PayloadMatchOne(PayloadMatch):
@@ -259,6 +227,7 @@ class PayloadMatchOne(PayloadMatch):
 
 class OnSubjectPropertyChanged(RuleFunctionBase):
     """
+
     *Specific function to filter* **subject-property-changed** *event.
     This event is produced whenever a subject property changes and its data contains the property name, the new property value and the old one.*
 

--- a/krules_core/base_functions/misc.py
+++ b/krules_core/base_functions/misc.py
@@ -13,30 +13,84 @@ from krules_core.base_functions import RuleFunctionBase
 
 class PyCall(RuleFunctionBase):
     """
-    Execute a generic python function
+    *Execute a generic python function.
+    Differently from* * **Process** *function, which returns nothing,
+    it allows to handle execution results whether it succeeds, using a functions which takes func result as unique argument,
+    or throws an exception, passing it to a chosen callable, developing a different logic for the two different cases.
+    By default an exception during func execution does not stop ruleset execution, by the way it is possible to
+    propagate any raised exception, setting **raise_on_error** *to True.*
+
+    ::
+
+        def post_to_api(url, data):
+            resp = requests.post(url, data)
+            resp.raise_for_status()
+            return resp
+
+        # ...
+
+        {
+            rulename: "on-device-onboarding-post-to-api",
+            subscibre_to: "device-onboarded",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    PyCall(
+                        post_to_api,
+                        kwargs={
+                            "url": "https://my_awesome_api/devices",
+                            "data": lambda payload: payload["device_info"],
+                        },
+                        on_success=lambda self:
+                            lambda ret:
+                                self.router.send(
+                                    subject="device-{}".format(ret.pop("uid"))
+                                    type="device-posted",
+                                    payload=ret
+                                )
+                        on_error=lambda self:
+                            lambda exc:
+                                self.router.send(
+                                    type="device-onboarded"
+                                    payload={
+                                        "device_info": self.payload["device_info"],
+                                        "retry_count": self.payload.get("retry_count", 0) + 1
+                                    }
+                                )
+                        payload_dest="api_response",
+                        raise_on_error=lambda payload: payload.get("retry_count", 0) > 2,
+                    )
+                ]
+            }
+
+            # ...
+        }
+
     """
 
     def execute(self, func, args=(), kwargs={}, on_success=None, on_error=None,
                 payload_dest="pycall_returns", raise_on_error=True):
         """
         Args:
-            func: function to call
-            args: function *args
-            kwargs: function **kwargs
-            on_success: function receiving (self, func_return_value)
-            on_error: callable, if func raises an exception this function is called receiving (self, exception)
-            payload_dest: key in payload storing func return value
-            raise_on_error: if False and func produce an exception, it is not raised
+            func: Function which will be to be executed.
+            args: *args that will be pass to **func**
+            kwargs: **kwargs that will be pass to **func**
+            on_success: Callable to handle **func** result which receive returned value as unique parameters.
+            on_error: Callable to handle **func** errors, if func raises an exception this function is called receiving the raised exception.
+            payload_dest: Payload's key in which func return value will be stored.
+            raise_on_error: Boolean value which indicates if func exceptions will be propagated
         """
 
         try:
             ret = func(*args, **kwargs)
             if on_success is not None:
-                on_success(self, ret)
+                on_success(ret)
             self.payload[payload_dest] = ret
         except Exception as exc:
             if on_error is not None:
-                on_error(self, exc)
+                on_error(exc)
             if raise_on_error:
                 raise exc
 

--- a/krules_core/base_functions/processing.py
+++ b/krules_core/base_functions/processing.py
@@ -13,67 +13,139 @@ from collections.abc import Mapping
 
 from krules_core.route.router import DispatchPolicyConst
 
-from krules_core.base_functions import RuleFunctionBase
+from krules_core.base_functions import RuleFunctionBase, Filter
+
+
+class Process(Filter):
+    """
+
+    *Extends* **Filter** *but does not return the given expression*
+    *The best way to exploit it is to use it in combination with* `Argument Processors <https://intro.krules.io/ArgumentProcessors.html>`_.
+
+    ::
+
+        from krules_core.types import RULE_PROC_EVENT
+
+        #...
+
+        {
+            # Supposing we want to store processed events with Django ORM
+            rulename: "processed-rules",
+            subscibre_to: RULE_PROC_EVENT,
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    Process(
+                        lambda payload:(
+                            ProcessedEvent.objects.create(
+                                rule_name=payload["name"],
+                                type=payload["type"],
+                                subject=payload["subject"],
+                                event_info=payload["event_info"],
+                                payload=payload["payload"],
+                                time=payload["event_info"].get("time", datetime.now().isoformat()),
+                                filters=payload["filters"],
+                                processing=payload["processing"],
+                                got_errors=payload["got_errors"],
+                                processed=payload["processed"],
+                                origin_id=payload["event_info"].get("originid", "-")
+                            )
+                        )
+                    ),
+                ]
+            }
+        }
+
+    """
+    def execute(self, value):
+        """
+
+        """
+        super().execute(value)
 
 
 ## PAYLOAD FUNCTIONS ##############################################################
 
-class UpdatePayload(RuleFunctionBase):
-    """
-    Update the payload _merging_ the received arguments interpreted as a dictionary
-    """
-
-    @staticmethod
-    def _update(d, u):
-        for k, v in u.items():
-            if isinstance(v, Mapping):
-                d[k] = UpdatePayload._update(d.get(k, {}), v)
-            elif isinstance(v, list):
-                v.extend(d.get(k, []))
-                d[k] = v
-            else:
-                d[k] = v
-        return d
-
-    def execute(self, merge_dict):
-        """
-        Args:
-            merge_dict: Dictionary to merge with
-        """
-        self._update(self.payload, merge_dict)
-
 
 class SetPayloadProperties(RuleFunctionBase):
     """
-    Set any number of properties in the payload. Existing properties are overridden
+    *Set the given properties in the payload, if some of that already exist will be overridden*
+
+    ::
+
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    SetPayloadProperties(  # Definition with a dictionary
+                        **{
+                            "has_admin_access": True,
+                            "last_login": datetime.now()
+                        }
+                    )
+                ]
+            }
+        },
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    SetPayloadProperties(  # Definition with named arguments
+                        has_admin_access=False,
+                        last_login=datetime.now()
+                    )
+                ]
+            }
+        },
     """
 
     def execute(self, **kwargs):
         """
         Args:
-              **kwargs: Each named paramenter is the key and the value to update with. The value can be a callable
-                and it receives _eventually_ the previous value for that key. This means that the callable should be declared
-                with a variable length number of arguments (*args)
+              **kwargs: Each named paramenter is the key and the value to update with.
         """
         for k, v in kwargs.items():
-            if inspect.isfunction(v):
-                args = []
-                if k in self.payload:
-                    args.append(self.payload[k])
-                v = v(*args)
             self.payload[k] = v
 
 
 class SetPayloadProperty(SetPayloadProperties):
     """
-    Set a single property
+    *Extends* **SetPayload** *expecting a single property to set*
+
+    ::
+
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    SetPayloadProperty(
+                        property_name="device_class",
+                        value="heather"
+                    )
+                ]
+            }
+        },
     """
 
     def execute(self, property_name, value):
         """
         Args:
-            property_name: A key in the dictionary,
-            value: Value to set. Can be a callable (see SetPayloadProperties)
+            property_name: Name of property which will be to set,
+            value: Value to set.
         """
         super().execute(**{property_name: value})
 
@@ -83,61 +155,115 @@ class SetPayloadProperty(SetPayloadProperties):
 
 class SetSubjectProperty(RuleFunctionBase):
     """
-    Set a single property of the subject
+    *Set a single property of the subject. By default, the property is reactive unless is muted (muted=True) or extended (extended=True)*
+
+    ::
+
+        {
+            rulename: "set-device-class",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    SetSubjectProperty(
+                        property_name="device_class",
+                        value="heather"
+                    )
+                ]
+            }
+        },
+        {
+            rulename: "on-new-checkup-increment-counter",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    SetSubjectProperty(
+                        property_name="checkup_cnt",
+                        value=lambda x: x is None and 1 or x + 1
+                    )
+                ]
+            }
+        }
+
     """
-    def execute(self, property_name, value, extended=False, muted=False, cached=True):
+    def execute(self, property_name, value, extended=False, muted=False, use_cache=True):
         """
         Args:
             property_name: Name of the property to set. It may or may not exist
             value: Value to set. It can be a callable and receives (optionally) the current property value.
-               If the property does not exist yet, it receives None
-               (it is not possible to discriminate from an existing variable with the value None)
+                If the property does not exist yet, it receives None.
+            extended: If True set an extended property instead a standard one. [default False]
+            muted: If True no subject-property-changed will be raised after property setting. Note that extended
+                properties are always muted so, if extended is True, this parameter will be ignored. [default False]
+            use_cache: If False store the property value immediately on the storage, otherwise wait for the end of rule execution. [default False]
         """
         if extended:
-            fn = lambda v: self.subject.set_ext(property_name, v, cached)
+            fn = lambda v: self.subject.set_ext(property_name, v, use_cache)
         else:
-            fn = lambda v: self.subject.set(property_name, v, muted, cached)
+            fn = lambda v: self.subject.set(property_name, v, muted, use_cache)
 
         return fn(value)
 
 
-class SetSubjectPropertySilently(SetSubjectProperty):
+class SetSubjectPropertyImmediately(SetSubjectProperty):
     """
-    Set a property silently (no property changed event)
-    """
-    def execute(self, property_name, value, extended=False, cached=True, **kwargs):
-        return super().execute(property_name, value, extended=extended, muted=True, cached=cached)
-
-
-class StoreSubjectProperty(SetSubjectProperty):
-    """
-    Set a property directly to the storage without using the cache
+    *Extends* **SetSubjectProperty** *setting a property directly to the storage without using the cache.
+    This could be very helpful to avoid concurrency issues by avoiding running into inconsistencies during the execution.
+    The extension's aim is to made code more readable.*
     """
     def execute(self, property_name, value, extended=False, muted=False, **kwargs):
-        return super().execute(property_name, value, extended=extended, muted=muted, cached=False)
+        """
 
-
-class StoreSubjectPropertySilently(SetSubjectProperty):
-    """
-    Set a property directly to the storage without using the cache and without emit property changed events
-    """
-    def execute(self, property_name, value, extended=False, **kwargs):
-        return super().execute(property_name, value, extended=extended, muted=True, cached=False)
+        """
+        return super().execute(property_name, value, extended=extended, muted=muted, use_cache=False)
 
 
 class SetSubjectExtendedProperty(SetSubjectProperty):
     """
-    Set an extended property of the subject
+    *Extends* **SetSubjectProperty** *setting an extended property of the subject. Note that* **muted** *is not
+    present anymore in the arguments because an extended property is always muted.
+    The extension's aim is to made code more readable.*
     """
-    def execute(self, property_name, value, cached=True, **kwargs):
-        return super().execute(property_name, value, extended=True, muted=True, cached=cached)
+    def execute(self, property_name, value, use_cache=True, **kwargs):
+        """
+
+        """
+        return super().execute(property_name, value, extended=True, muted=True, use_cache=use_cache)
 
 
 class SetSubjectProperties(RuleFunctionBase):
     """
-        Set multiple properties in subject from dictionary. This is allowed only by using cache
-        and not for extended properties
-        Selectively emit property changed events
+    *Set multiple properties in subject from dictionary. This is allowed only by using cache and not for
+    extended properties. Each property set in that way is muted but it is possible to unmute some of that using*
+    **unmuted** *parameter*
+
+    ::
+
+        {
+            rulename: "...",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    SetSubjectProperties(
+                        props= lambda: {
+                            "device_class": "heather",
+                            "on_boarding_tm": datetime.now(),
+                        },
+                        unmuted=["heather"]
+                    )
+                    # Thanks to ArgumentProcessor we can use a lambda, without that on_boarding_tm
+                    # would be always equal to the Rule instantiation's datetime while we need the execution's one.
+                ]
+            }
+        }
     """
 
     def execute(self, props, unmuted=[]):
@@ -150,48 +276,9 @@ class SetSubjectProperties(RuleFunctionBase):
             self.subject.set(name, value, muted=name not in unmuted)
 
 
-class IncrementSubjectProperty(RuleFunctionBase):
-    """
-    Increment a numeric property in the subject. This is a conveniencs functions
-    useful to accessing counters in a concurrent system. Implicitly
-    call directly the storage backend bypassing the cache
-    """
-    def execute(self, property_name, amount=1, muted=False):
-        if not isinstance(amount, (int, float, complex)):
-            raise TypeError("amount must be a numeric type")
-        return self.subject.set(
-            property_name, lambda x: x is None and 0 + amount or x + amount, muted, cached=False)
-
-
-class IncrementSubjectPropertySilently(IncrementSubjectProperty):
-
-    def execute(self, property_name, amount=1, **kwargs):
-        super().execute(property_name, amount, True)
-
-
-class DecrementSubjectProperty(RuleFunctionBase):
-    """
-    Increment a numeric property in the subject. This is a conveniencs functions
-    useful to accessing counters in a concurrent system. Implicitly
-    call directly the storage backend bypassing the cache
-    """
-    def execute(self, property_name, amount=1, is_mute=False):
-        if not isinstance(amount, (int, float, complex)):
-            raise TypeError("amount must be a numeric type")
-
-        return self.subject.set(
-            property_name, lambda x: x is None and 0 - amount or x - amount, is_mute, cached=False)
-
-
-class DecrementSubjectPropertySilently(DecrementSubjectProperty):
-
-    def execute(self, property_name, amount=1, **kwargs):
-        return super().execute(property_name, amount, True)
-
-
 class StoreSubject(RuleFunctionBase):
     """
-    Flush the cache
+    *Flush the cache. Usually the cache is flushed at the end of the rules execution.*
     """
 
     def execute(self):
@@ -200,7 +287,24 @@ class StoreSubject(RuleFunctionBase):
 
 class FlushSubject(RuleFunctionBase):
     """
-    Remove this subject and all of his properties
+    *Remove all subject's properties. It is important tho recall that a subject exists while it has at least a property,
+    so* **remove all its properties means remove the subject itself**.
+
+    ::
+
+        {
+            rulename: "on-user-unsubscribe-delete-subject",
+            subscibre_to: "...",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    FlushSubject()
+                ]
+            }
+        },
+
     """
 
     def execute(self):
@@ -212,23 +316,102 @@ class FlushSubject(RuleFunctionBase):
 
 class Route(RuleFunctionBase):
     """
-    Produce an event inside and/or outside the ruleset according to _dispatch_policy_
-    For "sending outside" the event we mean to deliver it to the dispatcher component
+    *Produce an event inside and/or outside the ruleset, for "sending outside" the event we mean to deliver it to the
+    dispatcher component.
+    By default an event is dispatched outside only if there is no handler defined in the current ruleset.
+    However it is possible to change this behavior using* **dispatch_policy**.
+    *Available choices are defined in* **krules_core.route.router.DispatchPolicyConst** *as:*
+        - **DEFAULT**: *Dispatched outside only when no handler is found in current ruleset;*
+        - **ALWAYS**: *Always dispatched outside even if an handler is found and processed in the current ruleset;*
+        - **NEVER**: *Never dispatched outside;*
+        - **DIRECT**: *Skip to search for a local handler and send outside directly.*
+
+    ::
+
+        from krules_core.route.router.DispatchPolicyConst import DEFAULT, ALWAYS, NEVER, DIRECT
+        from krules_core.types import SUBJECT_PROPERTY_CHANGED
+
+        # ...
+
+        {
+            rulename: "...",
+            subscibre_to: "device-uploaded",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    Route(
+                        subject=lambda payload: payload["device_id"],
+                        payload=lambda payload: payload["device_data"],
+                        type="device-added",
+                        # no dispatch_policy is provided so will be used the DEFAULT one
+                    ),
+                ]
+            }
+        },
+        {
+            rulename: "...",
+            subscibre_to: "device-upload-got-errors",
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    Route(
+                        type="device-uploaded",
+                        payload=lambda payload: payload["payload"]
+                        dispatch_policy=NEVER
+                        # no subject is provided so will be used the current one
+                    )
+                ]
+            }
+        },
+        {
+            rulename: "on-temp-change-propagate-event",
+            subscibre_to: SUBJECT_PROPERTY_CHANGED,
+            ruledata: {
+                filters: [
+                    ...
+                ]
+                processing: [
+                    Route(
+                        dispatch_policy=DIRECT
+                        # In this case we don't specify neither type, nor subject, nor payload.
+                        # We use dispatch_policy DIRECT to propagate the received event outside.
+                    )
+                ]
+            }
+        }
+
+        # ...
+        {
+            rulename: "on-resource-event-switch-subject",
+            subscribe_to: [
+                "dev.knative.apiserver.resource.add",
+                "dev.knative.apiserver.resource.update",
+                "dev.knative.apiserver.resource.delete",
+            ],
+            ruledata: {
+                processing: [
+                    Route(
+                        subject=lambda subject: "k8s:{}".format(subject.name),
+                        type=lambda self: "k8s.resource.{}".format(self.type.split(".")[-1]),
+                        dispatch_policy=DispatchPolicyConst.ALWAYS
+                        # no payload is provided so will be used the current one
+                    )
+                ]
+            }
+        },
     """
 
     def execute(self, type=None, subject=None, payload=None, dispatch_policy=DispatchPolicyConst.DEFAULT):
         """
         Args:
-            type: The event type. Default is current processing event type
-            subject: New subject or the current subject as default
-            payload: The payload of the event or the current payload
-            dispatch_policy: Router -> dispatcher policy. Available choices are defined in
-                 krules_core.route.router.DispatchPolicyConst as:
-
-                    DEFAULT: Dispatched outside only when no handler is found in current ruleset
-                    ALWAYS: Always dispatched even if an handler is found and processed in the current ruleset
-                    NEVER: Never dispatched outside
-                    DIRECT: Skip to search for a local handler and send outside directly
+            type: The event type. If None use current processing event type [default None]
+            subject: The event subject. If None use the current subject [default None]
+            payload: The event payload. If None use the current payload [default None]
+            dispatch_policy: Define the event dispatch policy as explained before. [default DispatchPolicyConst.DEFAULT]
         """
 
         from krules_core.providers import event_router_factory
@@ -242,14 +425,36 @@ class Route(RuleFunctionBase):
         event_router_factory().route(type, subject, payload, dispatch_policy=dispatch_policy)
 
 
-
-
 class RaiseException(RuleFunctionBase):
     """
-    Raise an exception
+    *Force the given exception raising*
+
+    ::
+
+        from .my_custom_exceptions import UnexpectedPayload # supposing we defined a module with custom exceptions
+
+        {
+            rulename: "on-unexpected-payload-raise-exception",
+            subscibre_to: "device-onboarded",
+            ruledata: {
+                filters: [
+                    Return(lambda payload: "device_id" not in payload)
+                ]
+                processing: [
+                    RaiseException(
+                        UnexpectedPayload("device_id missing!")
+                    )
+                ]
+            }
+        },
+
     """
 
     def execute(self, ex):
+        """
+        Args:
+            ex: The exception to be raised
+        """
 
         raise ex
 

--- a/krules_core/base_functions/processing.py
+++ b/krules_core/base_functions/processing.py
@@ -278,7 +278,7 @@ class SetSubjectProperties(RuleFunctionBase):
 
 class StoreSubject(RuleFunctionBase):
     """
-    *Flush the cache. Usually the cache is flushed at the end of the rules execution.*
+    *Flush the cache. Usually the cache is flushed at the end of the ruleset execution.*
     """
 
     def execute(self):

--- a/krules_core/core.py
+++ b/krules_core/core.py
@@ -129,7 +129,7 @@ class Rule:
                     _c = _c()
                 _cinst_name = _c.__class__.__name__
                 _cinst = type(_cinst_name, (_c.__class__,), {})()
-                _cinst.type = event_type
+                _cinst.event_type = event_type
                 _cinst.subject = subject
                 _cinst.payload = payload
                 res_in = {
@@ -181,7 +181,7 @@ class Rule:
                     _c = _c()
                 _cinst_name = _c.__class__.__name__
                 _cinst = type(_cinst_name, (_c.__class__,), {})()
-                _cinst.type = event_type
+                _cinst.event_type = event_type
                 _cinst.subject = subject
                 _cinst.payload = payload
                 res_in = {

--- a/krules_core/route/dispatcher.py
+++ b/krules_core/route/dispatcher.py
@@ -12,6 +12,6 @@
 
 class BaseDispatcher(object):
 
-    def dispatch(self, type, subject, payload, **extra):
+    def dispatch(self, event_type, subject, payload, **extra):
         from .router import logger
-        logger.debug("dispatch: {} {} {} | extra: {}".format(type, subject, payload, extra))
+        logger.debug("dispatch: {} {} {} | extra: {}".format(event_type, subject, payload, extra))

--- a/krules_core/route/router.py
+++ b/krules_core/route/router.py
@@ -27,29 +27,29 @@ class EventRouter(object):
     def __init__(self):
         self._callables = {}
 
-    def register(self, rule, type):
-        logger.debug("register {0} for {1}".format(rule, type))
-        if type not in self._callables:
-            self._callables[type] = []
-        self._callables[type].append(rule._process)
+    def register(self, rule, event_type):
+        logger.debug("register {0} for {1}".format(rule, event_type))
+        if event_type not in self._callables:
+            self._callables[event_type] = []
+        self._callables[event_type].append(rule._process)
 
-    def unregister(self, type):
-        logger.debug("unregister event {}".format(type))
+    def unregister(self, event_type):
+        logger.debug("unregister event {}".format(event_type))
         count = 0
-        if type in self._callables:
-            for r in self._callables[type]:
+        if event_type in self._callables:
+            for r in self._callables[event_type]:
                 count += 1
-            del self._callables[type]
+            del self._callables[event_type]
         return count
 
     def unregister_all(self):
         count = 0
         types = tuple(self._callables.keys())
-        for type in types:
-            count += self.unregister(type)
+        for event_type in types:
+            count += self.unregister(event_type)
         return count
 
-    def route(self, type, subject, payload, dispatch_policy=DispatchPolicyConst.DEFAULT):
+    def route(self, event_type, subject, payload, dispatch_policy=DispatchPolicyConst.DEFAULT):
 
         if isinstance(subject, str):
             # NOTE: this should have already happened if we want to take care or event info
@@ -58,13 +58,13 @@ class EventRouter(object):
 
         from ..providers import event_dispatcher_factory
 
-        _callables = self._callables.get(type, None)
+        _callables = self._callables.get(event_type, None)
 
         #        try:
         if not dispatch_policy == DispatchPolicyConst.DIRECT:
             if _callables is not None:
                 for _callable in _callables:
-                    _callable(type, subject, payload)
+                    _callable(event_type, subject, payload)
         #        finally:
         #            subject.store()
 
@@ -73,5 +73,5 @@ class EventRouter(object):
                 and dispatch_policy == DispatchPolicyConst.DEFAULT \
                 or dispatch_policy == DispatchPolicyConst.ALWAYS \
                 or dispatch_policy == DispatchPolicyConst.DIRECT:
-            logger.debug("dispatch {} to {} with payload {}".format(type, subject, payload))
-            return event_dispatcher_factory().dispatch(type, subject, payload)
+            logger.debug("dispatch {} to {} with payload {}".format(event_type, subject, payload))
+            return event_dispatcher_factory().dispatch(event_type, subject, payload)

--- a/krules_core/subject/storaged_subject.py
+++ b/krules_core/subject/storaged_subject.py
@@ -47,13 +47,13 @@ class Subject(object):
         self._cached[PropertyType.DEFAULT]["values"] = props
         self._cached[PropertyType.EXTENDED]["values"] = ext_props
 
-    def _set(self, prop, value, extended, muted, cached):
+    def _set(self, prop, value, extended, muted, use_cache):
         if isinstance(value, tuple):
             value = list(value)
 
-        if cached is None:
-            cached = self._use_cache
-        if cached:
+        if use_cache is None:
+            use_cache = self._use_cache
+        if use_cache:
             if self._cached is None:
                 self._load()
             kprops = extended and PropertyType.EXTENDED or PropertyType.DEFAULT
@@ -99,16 +99,16 @@ class Subject(object):
 
         return value, old_value
 
-    def set(self, prop, value, muted=False, cached=None):
-        return self._set(prop, value, False, muted, cached)
+    def set(self, prop, value, muted=False, use_cache=None):
+        return self._set(prop, value, False, muted, use_cache)
 
-    def set_ext(self, prop, value, cached=None):
-        return self._set(prop, value, True, True, cached)
+    def set_ext(self, prop, value, use_cache=None):
+        return self._set(prop, value, True, True, use_cache)
 
-    def _get(self, prop, extended, cached):
-        if cached is None:
-            cached = self._use_cache
-        if cached:
+    def _get(self, prop, extended, use_cache):
+        if use_cache is None:
+            use_cache = self._use_cache
+        if use_cache:
             if self._cached is None:
                 self._load()
             if extended:
@@ -130,16 +130,16 @@ class Subject(object):
                 self._cached[k]["updated"].add(prop)
             return val
 
-    def get(self, prop, cached=None):
-        return self._get(prop, False, cached)
+    def get(self, prop, use_cache=None):
+        return self._get(prop, False, use_cache)
 
-    def get_ext(self, prop, cached=None):
-        return self._get(prop, True, cached)
+    def get_ext(self, prop, use_cache=None):
+        return self._get(prop, True, use_cache)
 
-    def _delete(self, prop, extended, muted, cached):
-        if cached is None:
-            cached = self._use_cache
-        if cached:
+    def _delete(self, prop, extended, muted, use_cache):
+        if use_cache is None:
+            use_cache = self._use_cache
+        if use_cache:
             if self._cached is None:
                 self._load()
             k = extended and PropertyType.EXTENDED or PropertyType.DEFAULT
@@ -168,11 +168,11 @@ class Subject(object):
             from krules_core import types
             event_router_factory().route(types.SUBJECT_PROPERTY_DELETED, self, payload)
 
-    def delete(self, prop, muted=False, cached=None):
-        self._delete(prop, False, muted, cached)
+    def delete(self, prop, muted=False, use_cache=None):
+        self._delete(prop, False, muted, use_cache)
 
-    def delete_ext(self, prop, cached=None):
-        self._delete(prop, True, False, cached)
+    def delete_ext(self, prop, use_cache=None):
+        self._delete(prop, True, False, use_cache)
 
 
     def get_ext_props(self):
@@ -242,7 +242,7 @@ class Subject(object):
                     propname = item[4:]
                     is_ext = True
 
-                value = self._get(propname, extended=is_ext, cached=self._use_cache)
+                value = self._get(propname, extended=is_ext, use_cache=self._use_cache)
             except KeyError:
                 raise ex
             return _SubjectPropertyProxy(self, propname, value, is_ext, is_mute, self._use_cache)

--- a/krules_core/tests/base_functions/test_filters.py
+++ b/krules_core/tests/base_functions/test_filters.py
@@ -14,14 +14,9 @@ import re
 import pytest
 import rx
 from dependency_injector import providers
-<<<<<<< Updated upstream
 from krules_core.base_functions.filters import Filter, CheckSubjectProperty, PayloadMatch, SubjectNameMatch, \
     SubjectNameDoesNotMatch, PayloadMatchOne, OnSubjectPropertyChanged
-=======
-from krules_core.base_functions.filters import Returns, CheckSubjectProperty, CheckSubjectExtendedProperty, \
-    CheckStoredSubjectProperty, CheckPayloadMatch, SubjectMatch, SubjectDoesNotMatch, IsTrue, IsFalse, \
-    CheckPayloadMatchOne, OnSubjectPropertyChanged
->>>>>>> Stashed changes
+
 
 from krules_core import RuleConst
 
@@ -144,13 +139,9 @@ def test_subject_match(router, asserted):
                        subscribe_to='event-user-action',
                        data={
                            filters: [
-<<<<<<< Updated upstream
                                SubjectNameMatch(r"^user\|(?P<user_id>.+)", payload_dest="user_info"),
                                Filter(
-=======
-                               SubjectMatch(r"^user\|(?P<user_id>.+)", payload_dest="user_info"),
-                               IsTrue(
->>>>>>> Stashed changes
+
                                    lambda payload: "user_id" in payload.get("user_info", {})
                                )
                            ]
@@ -160,11 +151,7 @@ def test_subject_match(router, asserted):
                        subscribe_to='event-user-action',
                        data={
                            filters: [
-<<<<<<< Updated upstream
                                SubjectNameDoesNotMatch(r"^device\|(?P<device_id>.+)", payload_dest="device_info"),
-=======
-                               SubjectDoesNotMatch(r"^device\|(?P<device_id>.+)", payload_dest="device_info"),
->>>>>>> Stashed changes
                            ]
                        })
 

--- a/krules_core/tests/base_functions/test_filters.py
+++ b/krules_core/tests/base_functions/test_filters.py
@@ -14,8 +14,8 @@ import re
 import pytest
 import rx
 from dependency_injector import providers
-from krules_core.base_functions.filters import Returns, CheckSubjectProperty, PayloadMatch, SubjectNameMatch, \
-    SubjectNameDoesNotMatch, IsTrue, IsFalse, PayloadMatchOne, SubjectPropertyChanged
+from krules_core.base_functions.filters import Filter, CheckSubjectProperty, PayloadMatch, SubjectNameMatch, \
+    SubjectNameDoesNotMatch, PayloadMatchOne, OnSubjectPropertyChanged
 
 from krules_core import RuleConst
 
@@ -71,7 +71,7 @@ def test_return(subject, router, asserted):
                        subscribe_to="event-test-returns",
                        data={
                            filters: [
-                               Returns("something"),
+                               Filter("something"),
                            ],
                        })
 
@@ -94,21 +94,21 @@ def test_truth(subject, router, asserted):
                        subscribe_to="event-test-truth",
                        data={
                            filters: [
-                               IsTrue(
+                               Filter(
                                     lambda payload: payload["it-works"]
                                ),
                            ],
                        })
 
-    RuleFactory.create('test-is-false',
-                       subscribe_to="event-test-truth",
-                       data={
-                           filters: [
-                               IsFalse(
-                                   lambda payload: payload["it-works"] is False
-                               ),
-                           ],
-                       })
+    # RuleFactory.create('test-is-false',
+    #                    subscribe_to="event-test-truth",
+    #                    data={
+    #                        filters: [
+    #                            Filter(
+    #                                lambda payload: payload["it-works"] is False
+    #                            ),
+    #                        ],
+    #                    })
 
     proc_events_rx_factory().subscribe(
         lambda x: x[rulename] == 'test-is-true' and _assert(
@@ -127,7 +127,7 @@ def test_truth(subject, router, asserted):
     router.route("event-test-truth", subject, {'it-works': True})
 
     assert 'test-is-true' in asserted
-    assert 'test-is-false' in asserted
+    # assert 'test-is-false' in asserted
 
 
 def test_subject_match(router, asserted):
@@ -139,7 +139,7 @@ def test_subject_match(router, asserted):
                        data={
                            filters: [
                                SubjectNameMatch(r"^user\|(?P<user_id>.+)", payload_dest="user_info"),
-                               IsTrue(
+                               Filter(
                                    lambda payload: "user_id" in payload.get("user_info", {})
                                )
                            ]
@@ -213,7 +213,7 @@ def test_check_subject_property(router, subject, asserted):
 
     subject.set("prop-1", "value-1")
     subject.set("prop-2", 2)
-    subject.set_ext("ext-prop-2", "extprop")
+    subject.set_ext("ext-prop", "extprop")
 
     proc_events_rx_factory().subscribe(
         lambda x: x[rulename] == "test-simple-subject-property" and _assert(
@@ -227,11 +227,18 @@ def test_check_subject_property(router, subject, asserted):
             x[processed] is False
         )
     )
+    proc_events_rx_factory().subscribe(
+        lambda x: x[rulename] == "test-expr-subject-property" and _assert(
+            x[rulename],
+            x[processed] is True
+        )
+    )
 
     router.route("test-subject-property", subject, {})
 
     assert "test-simple-subject-property" in asserted
     assert "test-simple-subject-property-fails" in asserted
+    assert "test-expr-subject-property" in asserted
 
     # clean up
     router.unregister_all()
@@ -247,7 +254,7 @@ def test_check_subject_property(router, subject, asserted):
         subscribe_to="test-subject-property-direct",
         data={
             filters: [
-                CheckSubjectProperty("v-prop-1", "value-2", cached=False),  # prop-1 is still value-1
+                CheckSubjectProperty("v-prop-1", "value-2", use_cache=False),  # prop-1 is still value-1
             ]
         }
     )
@@ -257,7 +264,7 @@ def test_check_subject_property(router, subject, asserted):
         subscribe_to="test-subject-property-direct",
         data={
             filters: [
-                CheckSubjectProperty("ext-prop-3", cached=False),  # ext-prop-3 does not exists yet
+                CheckSubjectProperty("ext-prop-3", use_cache=False),  # ext-prop-3 does not exists yet
             ]
         }
     )
@@ -331,7 +338,7 @@ def test_check_payload_match(router, subject, asserted):
             filters: [
                 PayloadMatch("$.batch_data[?@.value>100]", lambda m: len(m) == 2),
                 PayloadMatch("$.batch_data[?@.value>100]", payload_dest="jpexpr_match"),
-                IsTrue(
+                Filter(
                     lambda payload: len(payload['jpexpr_match']) == 2
                 )
             ]
@@ -346,7 +353,7 @@ def test_check_payload_match(router, subject, asserted):
                 PayloadMatchOne("$.device_info.id", "0AFB1110"),
                 PayloadMatchOne("$.device_info.id", payload_dest="device_id"),
                 PayloadMatchOne("$.device.info.disabled", lambda disabled: not disabled),
-                IsTrue(
+                Filter(
                     lambda payload: payload["device_id"] == "0AFB1110"
                 )
             ]
@@ -390,14 +397,14 @@ def test_on_subject_property_changed(router, subject, asserted):
         subscribe_to=types.SUBJECT_PROPERTY_CHANGED,
         data={
             filters: [
-                SubjectPropertyChanged("prop_a"),
-                SubjectPropertyChanged(lambda: "prop_{}".format("a")),
-                SubjectPropertyChanged(lambda prop: re.match("prop_[a-z]", prop)),
-                SubjectPropertyChanged("prop_a", lambda: 1),
-                SubjectPropertyChanged("prop_a", value=lambda value: value > 0),
-                SubjectPropertyChanged("prop_a", value=lambda value, old_value: value == 1 and old_value is None),
-                SubjectPropertyChanged("prop_a", old_value=None),
-                SubjectPropertyChanged("prop_a", old_value=lambda old_value: old_value is None)
+                OnSubjectPropertyChanged("prop_a"),
+                OnSubjectPropertyChanged(lambda: "prop_{}".format("a")),
+                OnSubjectPropertyChanged(lambda prop: re.match("prop_[a-z]", prop)),
+                OnSubjectPropertyChanged("prop_a", lambda: 1),
+                OnSubjectPropertyChanged("prop_a", value=lambda value: value > 0),
+                OnSubjectPropertyChanged("prop_a", value=lambda value, old_value: value == 1 and old_value is None),
+                OnSubjectPropertyChanged("prop_a", old_value=None),
+                OnSubjectPropertyChanged("prop_a", old_value=lambda old_value: old_value is None)
            ]
         }
     )
@@ -406,7 +413,7 @@ def test_on_subject_property_changed(router, subject, asserted):
         subscribe_to=types.SUBJECT_PROPERTY_CHANGED,
         data={
             filters: [
-                SubjectPropertyChanged("prop_b"),
+                OnSubjectPropertyChanged("prop_b"),
            ]
         }
     )
@@ -415,7 +422,7 @@ def test_on_subject_property_changed(router, subject, asserted):
         subscribe_to=types.SUBJECT_PROPERTY_CHANGED,
         data={
             filters: [
-                SubjectPropertyChanged("prop_a", lambda value: value > 1),
+                OnSubjectPropertyChanged("prop_a", lambda value: value > 1),
             ]
         }
     )
@@ -424,7 +431,7 @@ def test_on_subject_property_changed(router, subject, asserted):
         subscribe_to=types.SUBJECT_PROPERTY_CHANGED,
         data={
             filters: [
-                SubjectPropertyChanged("prop_a", lambda value, old_value: value == 1 and old_value is not None),
+                OnSubjectPropertyChanged("prop_a", lambda value, old_value: value == 1 and old_value is not None),
             ]
         }
     )
@@ -433,7 +440,7 @@ def test_on_subject_property_changed(router, subject, asserted):
         subscribe_to=types.SUBJECT_PROPERTY_CHANGED,
         data={
             filters: [
-                SubjectPropertyChanged("prop_a", lambda value, old_value: value == 1,
+                OnSubjectPropertyChanged("prop_a", lambda value, old_value: value == 1,
                                          lambda old_value: old_value is not None),
             ]
         }

--- a/krules_core/tests/base_functions/test_filters.py
+++ b/krules_core/tests/base_functions/test_filters.py
@@ -14,8 +14,14 @@ import re
 import pytest
 import rx
 from dependency_injector import providers
+<<<<<<< Updated upstream
 from krules_core.base_functions.filters import Filter, CheckSubjectProperty, PayloadMatch, SubjectNameMatch, \
     SubjectNameDoesNotMatch, PayloadMatchOne, OnSubjectPropertyChanged
+=======
+from krules_core.base_functions.filters import Returns, CheckSubjectProperty, CheckSubjectExtendedProperty, \
+    CheckStoredSubjectProperty, CheckPayloadMatch, SubjectMatch, SubjectDoesNotMatch, IsTrue, IsFalse, \
+    CheckPayloadMatchOne, OnSubjectPropertyChanged
+>>>>>>> Stashed changes
 
 from krules_core import RuleConst
 
@@ -138,8 +144,13 @@ def test_subject_match(router, asserted):
                        subscribe_to='event-user-action',
                        data={
                            filters: [
+<<<<<<< Updated upstream
                                SubjectNameMatch(r"^user\|(?P<user_id>.+)", payload_dest="user_info"),
                                Filter(
+=======
+                               SubjectMatch(r"^user\|(?P<user_id>.+)", payload_dest="user_info"),
+                               IsTrue(
+>>>>>>> Stashed changes
                                    lambda payload: "user_id" in payload.get("user_info", {})
                                )
                            ]
@@ -149,7 +160,11 @@ def test_subject_match(router, asserted):
                        subscribe_to='event-user-action',
                        data={
                            filters: [
+<<<<<<< Updated upstream
                                SubjectNameDoesNotMatch(r"^device\|(?P<device_id>.+)", payload_dest="device_info"),
+=======
+                               SubjectDoesNotMatch(r"^device\|(?P<device_id>.+)", payload_dest="device_info"),
+>>>>>>> Stashed changes
                            ]
                        })
 

--- a/krules_core/tests/base_functions/test_misc.py
+++ b/krules_core/tests/base_functions/test_misc.py
@@ -79,8 +79,8 @@ def test_pycall(subject, router, asserted):
         data={
             processing: [
                 PyCall(_func, ([1, 2], True),
-                       on_success=lambda self, x: x.reverse(),
-                       on_error=lambda self, x: self.payload.update({"got_errors": True}))
+                       on_success=lambda self: lambda x: x.reverse(),
+                       on_error=lambda self: lambda x: self.payload.update({"got_errors": True}))
             ]
         }
     )
@@ -91,7 +91,7 @@ def test_pycall(subject, router, asserted):
         data={
             processing: [
                 PyCall(_func, ([1, 2],), kwargs={"raise_error": False},
-                       on_success=lambda self, x: (
+                       on_success=lambda self: lambda x: (
                            x.reverse(),
                            self.payload.update({"got_errors": False})
                        ))

--- a/krules_core/tests/subject/test_storaged_subject.py
+++ b/krules_core/tests/subject/test_storaged_subject.py
@@ -158,26 +158,26 @@ def test_set_get_del(subject):
     assert val == "silent" and len(_test_events) == 0
 
     # NO CACHE
-    subject.set("my-prop", 0, cached=False)  # not calling store
+    subject.set("my-prop", 0, use_cache=False)  # not calling store
     if subject_storage_factory(subject.name).is_persistent():
         subject = subject_factory(subject.name)
-        val = subject.get("my-prop", cached=False)
+        val = subject.get("my-prop", use_cache=False)
         assert val == 0
     #  with callables
-    val, old_val = subject.set("my-prop", lambda x: x+5, cached=False)
+    val, old_val = subject.set("my-prop", lambda x: x+5, use_cache=False)
     assert old_val == 0 and val == 5
     #  events produced
     assert len(_test_events) == 2
 
     # same with exts
     _test_events = []
-    subject.set_ext("my-prop", 0, cached=False)  # not calling store
+    subject.set_ext("my-prop", 0, use_cache=False)  # not calling store
     if subject_storage_factory(subject.name).is_persistent():
         subject = subject_factory(subject.name)
-        val = subject.get_ext("my-prop", cached=False)
+        val = subject.get_ext("my-prop", use_cache=False)
         assert val == 0
     #  with callables
-    val, old_val = subject.set_ext("my-prop", lambda x: x+5, cached=False)
+    val, old_val = subject.set_ext("my-prop", lambda x: x+5, use_cache=False)
     assert old_val == 0 and val == 5
     #  events NOT produced
     assert len(_test_events) == 0
@@ -187,7 +187,7 @@ def test_set_get_del(subject):
         subject = subject_factory(subject.name)
         val = subject.get("my-prop")
         assert val == 5  # prop cached
-        subject.set("my-prop", 1, cached=False)
+        subject.set("my-prop", 1, use_cache=False)
         val = subject.get("my-prop")  # from cache
         assert val == 1
         subject.store()
@@ -195,17 +195,17 @@ def test_set_get_del(subject):
         subject = subject_factory(subject.name)
         val = subject.get("my-prop")
         assert val == 1  # prop cached
-        subject.set("my-prop", 8, cached=True)
-        val = subject.get("my-prop", cached=False)  # update cache
+        subject.set("my-prop", 8, use_cache=True)
+        val = subject.get("my-prop", use_cache=False)  # update cache
         assert val == 1
-        val = subject.get("my-prop", cached=True)
+        val = subject.get("my-prop", use_cache=True)
         assert val == 1
         subject.store()
 
     # deletes
     _test_events = []
     #   cache not loaded yet
-    subject.delete("my-prop", cached=False)
+    subject.delete("my-prop", use_cache=False)
     assert len(_test_events) == 1 and \
         _test_events[0][0] == types.SUBJECT_PROPERTY_DELETED and \
         _test_events[0][1].name == subject.name and \
@@ -215,26 +215,26 @@ def test_set_get_del(subject):
     with pytest.raises(AttributeError):
         subject.delete("my-prop")
     # add prop bypassing cache
-    subject.set("my-prop", 0, cached=False)
-    subject.delete("my-prop", cached=True)
+    subject.set("my-prop", 0, use_cache=False)
+    subject.delete("my-prop", use_cache=True)
     subject.store()
     with pytest.raises(AttributeError):
         subject.get("my-prop")
     # add prop in cache remove directly
-    subject.set("my-prop", 0, cached=True)
-    subject.delete("my-prop", cached=False)
+    subject.set("my-prop", 0, use_cache=True)
+    subject.delete("my-prop", use_cache=False)
     subject.store()
     with pytest.raises(AttributeError):
         subject.get("my-prop")
     # all in cache
-    subject.set("my-prop", 0, cached=True)
-    subject.delete("my-prop", cached=True)
+    subject.set("my-prop", 0, use_cache=True)
+    subject.delete("my-prop", use_cache=True)
     subject.store()
     with pytest.raises(AttributeError):
         subject.get("my-prop")
     # no cache
-    subject.set("my-prop", 0, cached=False)
-    subject.delete("my-prop", cached=False)
+    subject.set("my-prop", 0, use_cache=False)
+    subject.delete("my-prop", use_cache=False)
     subject.store()
     with pytest.raises(AttributeError):
         subject.get("my-prop")
@@ -243,9 +243,9 @@ def test_set_get_del(subject):
 def test_get_ext_props(subject):
 
     # no cache
-    subject.set("my-prop-1", 0, cached=False)
-    subject.set_ext("my-prop-2", 2, cached=False)
-    subject.set_ext("my-prop-3", 3, cached=False)
+    subject.set("my-prop-1", 0, use_cache=False)
+    subject.set_ext("my-prop-2", 2, use_cache=False)
+    subject.set_ext("my-prop-3", 3, use_cache=False)
 
     props = subject.get_ext_props()
     assert len(props) == 2
@@ -253,8 +253,8 @@ def test_get_ext_props(subject):
     assert "my-prop-3" in props and props["my-prop-3"] == 3
 
     # with cache
-    subject.set_ext("my-prop-4", 4, cached=True)
-    subject.set("my-prop-5", 5, cached=True)
+    subject.set_ext("my-prop-4", 4, use_cache=True)
+    subject.set("my-prop-5", 5, use_cache=True)
     props = subject.get_ext_props()
     assert len(props) == 3
     assert "my-prop-2" in props and props["my-prop-2"] == 2

--- a/krules_core/tests/test_core.py
+++ b/krules_core/tests/test_core.py
@@ -110,8 +110,8 @@ def test_dispatch(subject, router):
 
     class _TestDispatcher(BaseDispatcher):
 
-        def dispatch(self, type, subject, payload, **extra):
-            _dispatched_events.append((type, subject, payload))
+        def dispatch(self, event_type, subject, payload, **extra):
+            _dispatched_events.append((event_type, subject, payload))
 
     event_dispatcher_factory.override(
         providers.Singleton(lambda: _TestDispatcher())
@@ -119,9 +119,9 @@ def test_dispatch(subject, router):
 
     router.route('test-unhandled-event', subject, {"data": 1})
 
-    type, subject, payload = _dispatched_events.pop()
+    t, subject, payload = _dispatched_events.pop()
     _assert(
-        type == 'test-unhandled-event' and
+        t == 'test-unhandled-event' and
         subject.name == subject.name and
         payload.get("data") == 1
     )


### PR DESCRIPTION
- Update base_functions docstrings;
- Replace Return, IsFalse and IsTrue with Filter;
- Refactor SubjectPropertyChanged to OnSubjectPropertyChanged;
- Add Process RuleFunction;
- Remove UpdatePayload, SetSubjectPropertySilently, IncrementSubjectProperty, DecrementSubjectProperty, StoreSubjectPropertySilently, IncrementSubjectPropertySilently, DecrementSubjectPropertySilently;
- Refactor StoreSubjectProperty to SetSubjectPropertyImmediately;
- PyCall on_success and on_error don't get anymore "self" as params;
- Refactor type to event_type;
- Refactor cached to use_cache.
