### PR TITLE
fix processed in filters

### DIFF
--- a/krules_core/base_functions/__init__.py
+++ b/krules_core/base_functions/__init__.py
@@ -83,6 +83,9 @@ class RuleFunctionBase:
 
     payload = {}
     event_type = ""
+    router = object()
+    configs = {}
+    rule_name = ""
 
     def __init__(self, *args, **kwargs):
         self._args = []
@@ -93,8 +96,6 @@ class RuleFunctionBase:
         for k, v in kwargs.items():
             self._kwargs[k] = self._get_arg_processor(v)
 
-        self.router = event_router_factory()
-        self.configs = configs_factory()
 
     @staticmethod
     def _get_arg_processor(arg):

--- a/krules_core/core.py
+++ b/krules_core/core.py
@@ -271,6 +271,8 @@ class Rule:
                 logger.error(res_out)
                 logger.debug("# unprocessed: {0}".format(res_out))
                 res_full[Const.GOT_ERRORS] = True
+                if Const.PROCESSED not in res_full:  # this happens when exception is in filters
+                    res_full[Const.PROCESSED] = False
                 res_full[res_out[Const.SECTION]].append(__clean(res_out))
                 proc_events_rx.on_next(res_full)
 

--- a/krules_core/core.py
+++ b/krules_core/core.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 
 from .subject import storaged_subject
 from . import RuleConst as Const
-from .providers import event_router_factory, subject_factory
+from .providers import event_router_factory, subject_factory, configs_factory
 
 import sys
 import traceback
@@ -149,6 +149,10 @@ class Rule:
                 _cinst.event_type = event_type
                 _cinst.subject = subject
                 _cinst.payload = payload
+                _cinst.rule_name = self.name
+                _cinst.router = event_router_factory()
+                _cinst.configs = configs_factory()
+
                 res_in = {
                     Const.PROCESS_ID: process_id,
                     Const.TYPE: event_type,
@@ -201,6 +205,9 @@ class Rule:
                 _cinst.event_type = event_type
                 _cinst.subject = subject
                 _cinst.payload = payload
+                _cinst.rule_name = self.name
+                _cinst.router = event_router_factory()
+                _cinst.configs = configs_factory()
                 res_in = {
                     Const.PROCESS_ID: process_id,
                     Const.TYPE: event_type,


### PR DESCRIPTION
When an exception occurred during the execution of the filter section, no 'processed' flag was generated in the produced metric (procevent). 
Now it is valued to False
